### PR TITLE
Increase Node.js memory limit in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ set_common_variables () {
     INSTALL_DIR_geo=$INSTALL_DIR/geodata
     TMP_DIR=/tmp/$(whoami)/immich-in-lxc/
     REPO_URL="https://github.com/immich-app/immich"
-    NODE_OPTIONS="--max-old-space-size=5096"
+    NODE_OPTIONS="--max-old-space-size=8192"
     set +a
 }
 


### PR DESCRIPTION
Lower memory limit leads to error 
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory